### PR TITLE
fix: 拦截鼠标Button4/Button5导航按钮，避免UI白屏

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -70,13 +70,24 @@ export class WindowManager {
     this.win.removeMenu();
 
     // DevTools 快捷键: F12 / Cmd+Shift+I / Ctrl+Shift+I
-    this.win.webContents.on("before-input-event", (_event, input) => {
+    // 同时拦截鼠标导航按钮(Button4/Button5)，避免在 file:// 协议下导致白屏
+    this.win.webContents.on("before-input-event", (event, input) => {
+      // DevTools 快捷键
       if (
         input.key === "F12" ||
         (input.control && input.shift && input.key.toLowerCase() === "i") ||
         (input.meta && input.shift && input.key.toLowerCase() === "i")
       ) {
         this.win?.webContents.toggleDevTools();
+        return;
+      }
+
+      // 拦截鼠标后退(Button4)和前进(Button5)按钮
+      // 在 file:// 协议下，这些按钮可能触发浏览器历史导航到无效路径，导致白屏
+      // input.button: 3 = Button4 (后退), 4 = Button5 (前进)
+      if (input.type === "mouseButton" && (input.button === 3 || input.button === 4)) {
+        event.preventDefault();
+        log.info(`已拦截鼠标导航按钮: Button${input.button + 1}`);
       }
     });
 


### PR DESCRIPTION
- 问题：在UI界面使用鼠标Button4（后退按钮）时，UI会进入白屏状态，
只有杀死后台程序重新启动才能恢复。


- 原因：OneClaw使用file://协议加载本地HTML，鼠标导航按钮触发的
浏览器历史导航可能指向无效路径（如父目录），导致页面加载失败。

- 修复：在before-input-event中拦截鼠标Button4(Button4)和
Button5(Button5)按钮，阻止其触发浏览器历史导航。

Fixes: https://github.com/oneclaw/oneclaw/issues/10