### PR TITLE
fix(skill-store): show toast on install/uninstall success and surface…

### DIFF
--- a/chat-ui/ui/src/ui/app-render.ts
+++ b/chat-ui/ui/src/ui/app-render.ts
@@ -347,11 +347,17 @@ async function installSkillFromStore(state: AppViewState, slug: string) {
     const result = await window.oneclaw.skillStoreInstall({ slug });
     if (result?.success) {
       skillStoreState.installedSlugs.add(slug);
+      await refreshInstalledSlugs();
+      showSkillStoreToast(state, t("skillStore.installSuccess"));
     } else {
-      showSkillStoreToast(state, t("skillStore.installFailed"));
+      const msg = result?.message
+        ? `${t("skillStore.installFailed")}: ${result.message}`
+        : t("skillStore.installFailed");
+      showSkillStoreToast(state, msg);
     }
-  } catch {
-    showSkillStoreToast(state, t("skillStore.installFailed"));
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
+    showSkillStoreToast(state, `${t("skillStore.installFailed")}: ${detail}`);
   }
   skillStoreState.installingSlugs.delete(slug);
   state.requestUpdate();
@@ -366,11 +372,17 @@ async function uninstallSkillFromStore(state: AppViewState, slug: string) {
     const result = await window.oneclaw.skillStoreUninstall({ slug });
     if (result?.success) {
       skillStoreState.installedSlugs.delete(slug);
+      await refreshInstalledSlugs();
+      showSkillStoreToast(state, t("skillStore.uninstallSuccess"));
     } else {
-      showSkillStoreToast(state, t("skillStore.uninstallFailed"));
+      const msg = result?.message
+        ? `${t("skillStore.uninstallFailed")}: ${result.message}`
+        : t("skillStore.uninstallFailed");
+      showSkillStoreToast(state, msg);
     }
-  } catch {
-    showSkillStoreToast(state, t("skillStore.uninstallFailed"));
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
+    showSkillStoreToast(state, `${t("skillStore.uninstallFailed")}: ${detail}`);
   }
   skillStoreState.installingSlugs.delete(slug);
   state.requestUpdate();

--- a/chat-ui/ui/src/ui/i18n.ts
+++ b/chat-ui/ui/src/ui/i18n.ts
@@ -90,6 +90,8 @@ const dict: Record<Locale, Record<string, string>> = {
     "skillStore.downloads": "下载量",
     "skillStore.installFailed": "安装失败，请稍后重试",
     "skillStore.uninstallFailed": "卸载失败，请稍后重试",
+    "skillStore.installSuccess": "安装成功",
+    "skillStore.uninstallSuccess": "卸载成功",
 
     // OneClaw settings page
     "settings.title": "设置",
@@ -228,6 +230,8 @@ const dict: Record<Locale, Record<string, string>> = {
     "skillStore.downloads": "Downloads",
     "skillStore.installFailed": "Install failed. Please try again later.",
     "skillStore.uninstallFailed": "Uninstall failed. Please try again later.",
+    "skillStore.installSuccess": "Installed successfully",
+    "skillStore.uninstallSuccess": "Uninstalled successfully",
 
     // OneClaw settings page
     "settings.title": "Settings",


### PR DESCRIPTION
… error details

When a skill installation or uninstallation failed, the UI silently reset the button to 'Install' with no feedback to the user (issue #18).

Changes:
- Show a success toast after a successful install or uninstall
- After success, call refreshInstalledSlugs() to sync the installed set from disk rather than relying solely on the in-memory optimistic update
- Surface the error message returned by the IPC handler (result.message) in the failure toast instead of showing a generic string
- Capture and display the thrown Error message in the catch branch
- Add i18n keys skillStore.installSuccess / skillStore.uninstallSuccess in both zh and en locales

Fixes #18