### PR TITLE
feat(chat-ui): add copy button to all message bubbles

### DIFF
--- a/chat-ui/ui/src/ui/chat/copy-as-markdown.ts
+++ b/chat-ui/ui/src/ui/chat/copy-as-markdown.ts
@@ -92,6 +92,6 @@ function createCopyButton(options: CopyButtonOptions): TemplateResult {
   `;
 }
 
-export function renderCopyAsMarkdownButton(markdown: string): TemplateResult {
-  return createCopyButton({ text: () => markdown, label: COPY_LABEL });
+export function renderCopyAsMarkdownButton(markdown: string, label?: string): TemplateResult {
+  return createCopyButton({ text: () => markdown, label: label ?? COPY_LABEL });
 }

--- a/chat-ui/ui/src/ui/chat/grouped-render.ts
+++ b/chat-ui/ui/src/ui/chat/grouped-render.ts
@@ -309,7 +309,7 @@ function renderGroupedMessage(
   const markdownBase = extractedText?.trim() ? extractedText : null;
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
   const markdown = markdownBase;
-  const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
+  const canCopyMarkdown = Boolean(markdown?.trim());
 
   // 检测纯 JSON 消息，用折叠块展示
   const jsonResult = markdown && !opts.isStreaming ? detectJson(markdown) : null;
@@ -346,7 +346,7 @@ function renderGroupedMessage(
 
   return html`
     <div class="${bubbleClasses}">
-      ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!) : nothing}
+      ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!, normalizedRole === "user" ? "Copy" : undefined) : nothing}
       ${
         isToolMessage
           ? html`


### PR DESCRIPTION
## Summary
- All message bubbles now show a copy button on hover (previously only assistant messages had one)
- User messages show "Copy", assistant messages show "Copy as markdown"
- Addresses user feedback #218: "需要复制按钮，自己划着鼠标选很容易选错"

## Test plan
- [ ] Hover over a user message → copy button appears in top-right
- [ ] Hover over an assistant message → copy button appears
- [ ] Click copy → content copied to clipboard, button shows check mark
- [ ] Tool/system messages without text content → no copy button

🤖 Generated with [Claude Code](https://claude.com/claude-code)