### PR TITLE
feat(provider): auto-detect image support instead of manual checkbox

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -267,14 +267,6 @@
           </div>
         </div>
 
-        <!-- Custom: 图像支持 -->
-        <div class="field-group hidden" id="imageSupportGroup">
-          <label class="checkbox-item">
-            <input type="checkbox" id="supportImage" checked>
-            <span data-i18n="provider.supportImage">Supports image input</span>
-          </label>
-        </div>
-
         <!-- 错误 / 成功信息 -->
         <div class="msg-box hidden" id="msgBox"></div>
 

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -148,7 +148,6 @@
       "provider.model": "Model",
       "provider.modelId": "Model ID",
       "provider.apiType": "API Type",
-      "provider.supportImage": "Supports image input",
       "provider.oauthLogin": "Log in with Kimi",
       "provider.oauthCancel": "Cancel",
       "provider.oauthLogout": "Log out",
@@ -455,7 +454,6 @@
       "provider.model": "模型",
       "provider.modelId": "模型 ID",
       "provider.apiType": "接口类型",
-      "provider.supportImage": "支持图像输入",
       "provider.oauthLogin": "Kimi 会员登录",
       "provider.oauthCancel": "取消",
       "provider.oauthLogout": "退出登录",
@@ -759,8 +757,6 @@
     modelInputGroup: $("#modelInputGroup"),
     modelInput: $("#modelInput"),
     apiTypeGroup: $("#apiTypeGroup"),
-    imageSupportGroup: $("#imageSupportGroup"),
-    supportImageCheckbox: $("#supportImage"),
     customPresetGroup: $("#customPresetGroup"),
     customPreset: $("#customPreset"),
     customModelInputGroup: $("#customModelInputGroup"),
@@ -1226,13 +1222,11 @@
 
     if (isCustom) {
       els.customPreset.value = "__placeholder__";
-      els.supportImageCheckbox.checked = true;
       applyCustomPreset("__placeholder__");
     } else {
       toggleEl(els.baseURLGroup, false);
       toggleEl(els.modelInputGroup, false);
       toggleEl(els.apiTypeGroup, false);
-      toggleEl(els.imageSupportGroup, false);
       toggleEl(els.customModelInputGroup, false);
       toggleEl(els.modelSelectGroup, true);
       els.btnSave.disabled = false;
@@ -1259,7 +1253,7 @@
       // 占位状态：隐藏所有字段，禁用保存按钮
       toggleEl(els.baseURLGroup, false);
       toggleEl(els.apiTypeGroup, false);
-      toggleEl(els.imageSupportGroup, false);
+
       toggleEl(els.modelInputGroup, false);
       toggleEl(els.modelSelectGroup, false);
       toggleEl(els.customModelInputGroup, false);
@@ -1269,7 +1263,7 @@
     } else if (preset) {
       // 预设模式：隐藏手动字段
       toggleEl(els.apiTypeGroup, false);
-      toggleEl(els.imageSupportGroup, false);
+
       toggleEl(els.modelInputGroup, false);
       toggleEl(els.baseURLGroup, false);
       toggleEl(els.apiKeyGroup, true);
@@ -1288,7 +1282,7 @@
       // 手动模式：恢复原始 Custom 行为
       toggleEl(els.baseURLGroup, true);
       toggleEl(els.apiTypeGroup, true);
-      toggleEl(els.imageSupportGroup, true);
+
       toggleEl(els.modelInputGroup, true);
       toggleEl(els.modelSelectGroup, false);
       toggleEl(els.customModelInputGroup, false);
@@ -1724,6 +1718,9 @@
         return;
       }
 
+      // 使用后端探测到的图片能力
+      params.supportImage = verifyResult.supportsImage ?? true;
+
       // 构造保存 payload，注入 action / modelKey / 别名
       var payload = buildSavePayload(params);
       var alias = (els.modelAlias.value || "").trim();
@@ -1789,7 +1786,6 @@
         params.baseURL = baseURL;
         params.modelID = modelID;
         params.apiType = document.querySelector('input[name="apiType"]:checked').value;
-        params.supportImage = els.supportImageCheckbox.checked;
       }
     } else {
       // 非 custom provider：支持自定义模型输入
@@ -4078,7 +4074,6 @@
           var apiRadio = document.querySelector('input[name="apiType"][value="' + data.api + '"]');
           if (apiRadio) apiRadio.checked = true;
         }
-        els.supportImageCheckbox.checked = data.supportsImage !== false;
       }
 
       // 更新当前 provider 状态指示

--- a/setup/index.html
+++ b/setup/index.html
@@ -228,14 +228,6 @@
           </div>
         </div>
 
-        <!-- Custom: 图片支持 -->
-        <div class="field-group hidden" id="imageSupportGroup">
-          <label class="checkbox-item">
-            <input type="checkbox" id="imageSupport" checked>
-            <span data-i18n="config.imageSupport">Model supports image input</span>
-          </label>
-        </div>
-
         <!-- 错误信息 -->
         <div class="error-msg hidden" id="errorMsg"></div>
 

--- a/setup/setup.js
+++ b/setup/setup.js
@@ -135,7 +135,6 @@
       "config.docsLink": "Tutorial Docs →",
       "config.back": "Back",
       "config.verify": "Verify & Continue",
-      "config.imageSupport": "Model supports image input",
       "config.oauthLogin": "Log in with Kimi",
       "config.oauthCancel": "Cancel",
       "config.oauthWaiting": "Waiting for authorization in browser…",
@@ -201,7 +200,6 @@
       "config.docsLink": "教程文档 →",
       "config.back": "返回",
       "config.verify": "验证并继续",
-      "config.imageSupport": "模型支持图片输入",
       "config.oauthLogin": "Kimi 会员登录",
       "config.oauthCancel": "取消",
       "config.oauthWaiting": "请在浏览器中完成授权…",
@@ -262,8 +260,6 @@
     modelInputGroup: $("#modelInputGroup"),
     modelInput: $("#modelInput"),
     apiTypeGroup: $("#apiTypeGroup"),
-    imageSupportGroup: $("#imageSupportGroup"),
-    imageSupport: $("#imageSupport"),
     customPresetGroup: $("#customPresetGroup"),
     customPreset: $("#customPreset"),
     customModelInputGroup: $("#customModelInputGroup"),
@@ -470,7 +466,6 @@
       toggleEl(els.baseURLGroup, false);
       toggleEl(els.modelInputGroup, false);
       toggleEl(els.apiTypeGroup, false);
-      toggleEl(els.imageSupportGroup, false);
       toggleEl(els.customModelInputGroup, false);
       toggleEl(els.modelSelectGroup, true);
       els.btnVerify.disabled = false;
@@ -490,7 +485,6 @@
       // 占位状态：隐藏所有字段，禁用验证按钮
       toggleEl(els.baseURLGroup, false);
       toggleEl(els.apiTypeGroup, false);
-      toggleEl(els.imageSupportGroup, false);
       toggleEl(els.modelInputGroup, false);
       toggleEl(els.modelSelectGroup, false);
       toggleEl(els.customModelInputGroup, false);
@@ -500,7 +494,6 @@
     } else if (preset) {
       // 预设模式：隐藏手动字段
       toggleEl(els.apiTypeGroup, false);
-      toggleEl(els.imageSupportGroup, false);
       toggleEl(els.modelInputGroup, false);
       toggleEl(els.baseURLGroup, false);
       toggleEl(els.apiKeyGroup, true);
@@ -519,7 +512,6 @@
       // 手动模式：恢复原始 Custom 行为
       toggleEl(els.baseURLGroup, true);
       toggleEl(els.apiTypeGroup, true);
-      toggleEl(els.imageSupportGroup, true);
       toggleEl(els.modelInputGroup, true);
       toggleEl(els.modelSelectGroup, false);
       toggleEl(els.customModelInputGroup, false);
@@ -669,7 +661,7 @@
         baseURL: "",
         api: "",
         subPlatform: "kimi-code",
-        supportImage: true,
+        supportImage: verifyResult.supportsImage ?? true,
         customPreset: "",
       });
 
@@ -733,6 +725,8 @@
         return;
       }
 
+      // 使用后端探测到的图片能力
+      params.supportImage = result.supportsImage ?? true;
       await window.oneclaw.saveConfig(buildSavePayload(params));
       setVerifying(false);
       goToStep(3);
@@ -780,7 +774,6 @@
         params.baseURL = baseURL;
         params.modelID = modelID;
         params.apiType = document.querySelector('input[name="apiType"]:checked').value;
-        params.supportImage = els.imageSupport.checked;
       }
     } else {
       // 非 custom provider：支持自定义模型输入

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,7 @@ import { uninstallGatewayDaemon, killPortProcess, getPortPid } from "./install-d
 import { detectOwnership, migrateFromLegacy, markSetupComplete, readOneclawConfig, writeOneclawConfig } from "./oneclaw-config";
 import { startTokenRefresh, stopTokenRefresh, loadOAuthToken } from "./kimi-oauth";
 import { startAuthProxy, stopAuthProxy, setProxyAccessToken, setProxySearchDedicatedKey, getProxyPort } from "./kimi-auth-proxy";
+import { loadModelCatalog } from "./model-catalog";
 import * as log from "./logger";
 import * as analytics from "./analytics";
 
@@ -818,6 +819,10 @@ app.whenReady().then(async () => {
   } else {
     Menu.setApplicationMenu(null);
   }
+  // 后台加载 openclaw 模型目录，用于 Setup/Settings 写入精确的 input 能力。
+  // 不阻塞启动——加载失败时 buildProviderConfig 回退到默认值。
+  loadModelCatalog().catch(() => {});
+
   analytics.init();
   analytics.track("app_launched");
   setupAutoUpdater();

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -1,0 +1,78 @@
+// 模型能力目录 — 从 openclaw 的 `models list --all --json` 缓存权威数据。
+// Setup / Settings 保存时通过 getModelInput() 查询，避免硬编码 input 字段。
+
+import { execFile } from "child_process";
+import { resolveNodeBin, resolveGatewayEntry, resolveNodeExtraEnv } from "./constants";
+import * as log from "./logger";
+
+interface CatalogEntry {
+  input: string[];   // ["text"] or ["text", "image"]
+  name: string;
+  contextWindow?: number;
+}
+
+// provider/modelId → CatalogEntry
+let catalog: Map<string, CatalogEntry> | null = null;
+
+// openclaw 的 providerKey 可能跟 OneClaw 的 CUSTOM_PROVIDER_PRESETS.providerKey 不完全一致。
+// 这张表把 OneClaw 的 key 映射到 openclaw catalog 里实际使用的 key。
+const PROVIDER_KEY_ALIASES: Record<string, string> = {
+  "zai-global": "zai",
+  "zai-cn": "zai",
+  "zai-cn-coding": "zai",
+};
+
+function normalizeProviderKey(key: string): string {
+  return PROVIDER_KEY_ALIASES[key] || key;
+}
+
+/**
+ * 调用 openclaw CLI 加载全量模型目录，缓存到内存。
+ * 启动期后台调用，不阻塞主流程。失败时 catalog 保持 null（lookup 返回 undefined）。
+ */
+export async function loadModelCatalog(): Promise<void> {
+  try {
+    const nodeBin = resolveNodeBin();
+    const entry = resolveGatewayEntry();
+    const stdout = await new Promise<string>((resolve, reject) => {
+      execFile(
+        nodeBin,
+        [entry, "models", "list", "--all", "--json"],
+        {
+          env: { ...process.env, ...resolveNodeExtraEnv(), OPENCLAW_NO_RESPAWN: "1" },
+          maxBuffer: 4_000_000,
+          timeout: 30_000,
+        },
+        (err, stdout, stderr) => {
+          if (err) return reject(err);
+          resolve(stdout);
+        },
+      );
+    });
+
+    const parsed = JSON.parse(stdout);
+    const map = new Map<string, CatalogEntry>();
+    for (const m of parsed.models ?? []) {
+      const key: string = m.key;  // "minimax/MiniMax-M2.5"
+      const inputStr: string = m.input ?? "text";
+      const input = inputStr.includes("image") ? ["text", "image"] : ["text"];
+      map.set(key, { input, name: m.name, contextWindow: m.contextWindow });
+    }
+    catalog = map;
+    log.info(`[model-catalog] loaded ${map.size} models`);
+  } catch (err: any) {
+    log.error(`[model-catalog] load failed: ${err?.message ?? err}`);
+    // catalog stays null → getModelInput() returns undefined → callers fall back
+  }
+}
+
+/**
+ * 查询模型的 input 能力。
+ * @returns ["text"] / ["text","image"] — 命中目录时返回权威值
+ *          undefined — 未加载或未命中（调用方自行决定 fallback）
+ */
+export function getModelInput(providerKey: string, modelId: string): string[] | undefined {
+  if (!catalog) return undefined;
+  const normalizedKey = normalizeProviderKey(providerKey);
+  return catalog.get(`${normalizedKey}/${modelId}`)?.input;
+}

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -13,6 +13,8 @@ interface CatalogEntry {
 
 // provider/modelId → CatalogEntry
 let catalog: Map<string, CatalogEntry> | null = null;
+// modelId → CatalogEntry（跨 provider fallback：同一物理模型经不同 provider 路由时能力不变）
+let catalogByModelId: Map<string, CatalogEntry> | null = null;
 
 // openclaw 的 providerKey 可能跟 OneClaw 的 CUSTOM_PROVIDER_PRESETS.providerKey 不完全一致。
 // 这张表把 OneClaw 的 key 映射到 openclaw catalog 里实际使用的 key。
@@ -52,14 +54,20 @@ export async function loadModelCatalog(): Promise<void> {
 
     const parsed = JSON.parse(stdout);
     const map = new Map<string, CatalogEntry>();
+    const byModelId = new Map<string, CatalogEntry>();
     for (const m of parsed.models ?? []) {
       const key: string = m.key;  // "minimax/MiniMax-M2.5"
+      const modelId = key.includes("/") ? key.slice(key.indexOf("/") + 1) : key;
       const inputStr: string = m.input ?? "text";
       const input = inputStr.includes("image") ? ["text", "image"] : ["text"];
-      map.set(key, { input, name: m.name, contextWindow: m.contextWindow });
+      const entry: CatalogEntry = { input, name: m.name, contextWindow: m.contextWindow };
+      map.set(key, entry);
+      // 同一 modelId 首次出现的 provider 作为 fallback（802 模型仅 1 例 conflict）
+      if (!byModelId.has(modelId)) byModelId.set(modelId, entry);
     }
     catalog = map;
-    log.info(`[model-catalog] loaded ${map.size} models`);
+    catalogByModelId = byModelId;
+    log.info(`[model-catalog] loaded ${map.size} models (${byModelId.size} unique)`);
   } catch (err: any) {
     log.error(`[model-catalog] load failed: ${err?.message ?? err}`);
     // catalog stays null → getModelInput() returns undefined → callers fall back
@@ -68,11 +76,18 @@ export async function loadModelCatalog(): Promise<void> {
 
 /**
  * 查询模型的 input 能力。
+ * 优先按 provider/modelId 精确匹配；未命中时按 modelId 跨 provider fallback。
+ * 同一物理模型经不同 provider 路由（如 volcengine-coding 代理 MiniMax-M2.5），
+ * 图片能力由模型本身决定，不随 provider 变化。
  * @returns ["text"] / ["text","image"] — 命中目录时返回权威值
  *          undefined — 未加载或未命中（调用方自行决定 fallback）
  */
 export function getModelInput(providerKey: string, modelId: string): string[] | undefined {
   if (!catalog) return undefined;
   const normalizedKey = normalizeProviderKey(providerKey);
-  return catalog.get(`${normalizedKey}/${modelId}`)?.input;
+  // 精确匹配 provider/modelId
+  const exact = catalog.get(`${normalizedKey}/${modelId}`);
+  if (exact) return exact.input;
+  // 跨 provider fallback：仅按 modelId 查询
+  return catalogByModelId?.get(modelId)?.input;
 }

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -52,7 +52,16 @@ export async function loadModelCatalog(): Promise<void> {
       );
     });
 
-    const parsed = JSON.parse(stdout);
+    // openclaw CLI 的 plugin loader 会把注册日志（带 ANSI 色码）打到 stdout，
+    // 污染 JSON payload 前面的字节。切到首个 `{` 开始解析，兼容未来污染行数变化。
+    const jsonStart = stdout.indexOf("{");
+    if (jsonStart < 0) {
+      throw new Error("no JSON payload in openclaw models list output");
+    }
+    if (jsonStart > 0) {
+      log.warn(`[model-catalog] stripped ${jsonStart} bytes of non-JSON preamble from CLI stdout`);
+    }
+    const parsed = JSON.parse(stdout.slice(jsonStart));
     const map = new Map<string, CatalogEntry>();
     const byModelId = new Map<string, CatalogEntry>();
     for (const m of parsed.models ?? []) {

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -3,6 +3,7 @@ import * as http from "http";
 import * as fs from "fs";
 import { resolveUserConfigPath, resolveUserStateDir } from "./constants";
 import { backupCurrentUserConfig } from "./config-backup";
+import { getModelInput } from "./model-catalog";
 
 // ── Provider 配置预设（与 kimiclaw ProviderSetupView.swift 对齐） ──
 
@@ -132,29 +133,36 @@ export function buildProviderConfig(
 ): Record<string, unknown> {
   const preset = PROVIDER_PRESETS[provider];
 
-  // 预设 provider（Anthropic/OpenAI/Google）一律声明图片能力
+  // 解析 configKey（用于 catalog 查询）
+  const customPre = customPreset ? CUSTOM_PROVIDER_PRESETS[customPreset] : undefined;
+  const configKey = customPre
+    ? customPre.providerKey
+    : preset ? provider : (baseURL ? deriveCustomConfigKey(baseURL) : "custom");
+
+  // 优先查询 openclaw 权威模型目录；未命中时回退到 supportImage 参数
+  const catalogInput = getModelInput(configKey, modelID);
+  const input = catalogInput ?? (supportImage !== false ? ["text", "image"] : ["text"]);
+
   if (preset) {
     return {
       apiKey,
       baseUrl: preset.baseUrl,
       api: preset.api,
-      models: [{ id: modelID, name: modelID, input: ["text", "image"] }],
+      models: [{ id: modelID, name: modelID, input }],
     };
   }
 
   // Custom 内置预设命中时，使用预设的 baseUrl 和 api（前端传了 baseURL 时优先用前端值）
-  const customPre = customPreset ? CUSTOM_PROVIDER_PRESETS[customPreset] : undefined;
   if (customPre) {
     return {
       apiKey,
       baseUrl: baseURL || customPre.baseUrl,
       api: customPre.api,
-      models: [{ id: modelID, name: modelID, input: ["text", "image"] }],
+      models: [{ id: modelID, name: modelID, input }],
     };
   }
 
-  // Custom provider — 根据用户勾选决定是否声明图片能力
-  const input = supportImage !== false ? ["text", "image"] : ["text"];
+  // Custom manual provider
   return {
     apiKey,
     baseUrl: baseURL,
@@ -174,12 +182,16 @@ export function saveMoonshotConfig(
   const sub = MOONSHOT_SUB_PLATFORMS[subPlatform] || MOONSHOT_SUB_PLATFORMS["moonshot-cn"];
   const providerKey = sub.providerKey;
 
+  // 优先查询 openclaw 权威模型目录
+  const catalogInput = getModelInput(providerKey, modelID);
+  const input = catalogInput ?? ["text", "image"];
+
   // 所有子平台统一写法：apiKey + baseUrl + api + models 写入 providers
   config.models.providers[providerKey] = {
     apiKey,
     baseUrl: sub.baseUrl,
     api: sub.api,
-    models: [{ id: modelID, name: modelID, input: ["text", "image"], reasoning: true }],
+    models: [{ id: modelID, name: modelID, input, reasoning: true }],
   };
 
   config.agents.defaults.model.primary = `${providerKey}/${modelID}`;
@@ -432,119 +444,6 @@ export async function verifyCustom(apiKey: string, baseURL?: string, apiType?: s
   }
 }
 
-// ── 图片能力探测 ──
-
-// 1x1 transparent PNG (67 bytes) as base64
-const TINY_PNG_B64 =
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAB" +
-  "Nl7BcQAAAABJRU5ErkJggg==";
-
-// 文本验证成功后，发一次带图片的请求来探测模型是否支持图片输入。
-// 只对有 modelID 且走 chat 接口的 provider 有意义（跳过 feishu/qqbot/dingtalk 等凭证型）。
-async function probeImageSupport(params: {
-  provider: string;
-  apiKey?: string;
-  baseURL?: string;
-  subPlatform?: string;
-  apiType?: string;
-  modelID?: string;
-  customPreset?: string;
-  proxyPort?: number;
-}): Promise<boolean> {
-  const { provider, apiKey, baseURL, subPlatform, apiType, modelID, customPreset, proxyPort } = params;
-
-  // 确定实际的 API 类型和 base URL
-  let effectiveApi: string;
-  let effectiveBase: string;
-
-  if (provider === "anthropic") {
-    effectiveApi = "anthropic-messages";
-    effectiveBase = PROVIDER_PRESETS.anthropic.baseUrl;
-  } else if (provider === "openai") {
-    effectiveApi = "openai-completions";
-    effectiveBase = PROVIDER_PRESETS.openai.baseUrl;
-  } else if (provider === "google") {
-    // Google Generative AI 验证走 /models 端点，不走 chat，且主流模型均支持图片
-    return true;
-  } else if (provider === "moonshot") {
-    if (subPlatform === "kimi-code") {
-      effectiveApi = "anthropic-messages";
-      effectiveBase = `http://127.0.0.1:${proxyPort}/coding`;
-    } else {
-      const sub = MOONSHOT_SUB_PLATFORMS[subPlatform || "moonshot-cn"] || MOONSHOT_SUB_PLATFORMS["moonshot-cn"];
-      effectiveApi = sub.api;
-      effectiveBase = sub.baseUrl;
-    }
-  } else if (provider === "custom") {
-    const customPre = customPreset ? CUSTOM_PROVIDER_PRESETS[customPreset] : undefined;
-    effectiveBase = (baseURL || (customPre ? customPre.baseUrl : ""))!.replace(/\/$/, "");
-    effectiveApi = customPre ? customPre.api : (apiType || "openai-completions");
-  } else {
-    // feishu/qqbot/dingtalk 等无 chat 接口的 provider — 默认不支持
-    return false;
-  }
-
-  if (!effectiveBase || !modelID) return true; // 无法探测时保守返回 true
-
-  try {
-    if (effectiveApi === "anthropic-messages") {
-      const url = effectiveBase.replace(/\/$/, "") + "/v1/messages";
-      const headers: Record<string, string> = {
-        "User-Agent": UA_ANTHROPIC,
-        "anthropic-version": "2023-06-01",
-        "content-type": "application/json",
-      };
-      // kimi-code 走代理无需 x-api-key；其他需要
-      if (apiKey && provider !== "moonshot") headers["x-api-key"] = apiKey;
-      if (provider === "moonshot" && subPlatform !== "kimi-code" && apiKey) headers["x-api-key"] = apiKey;
-
-      await jsonRequest(url, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          model: modelID,
-          max_tokens: 1,
-          messages: [{
-            role: "user",
-            content: [
-              { type: "image", source: { type: "base64", media_type: "image/png", data: TINY_PNG_B64 } },
-              { type: "text", text: "hi" },
-            ],
-          }],
-        }),
-      });
-      return true;
-    } else if (effectiveApi === "openai-completions") {
-      const url = effectiveBase.replace(/\/$/, "") + "/chat/completions";
-      await jsonRequest(url, {
-        method: "POST",
-        headers: {
-          "User-Agent": UA_OPENAI,
-          Authorization: `Bearer ${apiKey}`,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          model: modelID,
-          max_tokens: 1,
-          messages: [{
-            role: "user",
-            content: [
-              { type: "image_url", image_url: { url: `data:image/png;base64,${TINY_PNG_B64}` } },
-              { type: "text", text: "hi" },
-            ],
-          }],
-        }),
-      });
-      return true;
-    }
-    // openai-responses / google-generative-ai 等不易探测，保守返回 true
-    return true;
-  } catch {
-    // 请求失败说明模型不支持图片
-    return false;
-  }
-}
-
 // ── 统一验证入口（根据 provider 名称分派） ──
 
 export async function verifyProvider(params: {
@@ -560,7 +459,7 @@ export async function verifyProvider(params: {
   clientSecret?: string;
   customPreset?: string;
   proxyPort?: number;
-}): Promise<{ success: boolean; message?: string; supportsImage?: boolean }> {
+}): Promise<{ success: boolean; message?: string }> {
   const {
     provider,
     apiKey,
@@ -615,10 +514,7 @@ export async function verifyProvider(params: {
         return { success: false, message: `未知 Provider: ${provider}` };
     }
 
-    // 文本验证通过后，自动探测图片能力
-    const supportsImage = await probeImageSupport(params);
-
-    return { success: true, supportsImage };
+    return { success: true };
   } catch (err: any) {
     return { success: false, message: err.message || String(err) };
   }

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -432,6 +432,119 @@ export async function verifyCustom(apiKey: string, baseURL?: string, apiType?: s
   }
 }
 
+// ── 图片能力探测 ──
+
+// 1x1 transparent PNG (67 bytes) as base64
+const TINY_PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAB" +
+  "Nl7BcQAAAABJRU5ErkJggg==";
+
+// 文本验证成功后，发一次带图片的请求来探测模型是否支持图片输入。
+// 只对有 modelID 且走 chat 接口的 provider 有意义（跳过 feishu/qqbot/dingtalk 等凭证型）。
+async function probeImageSupport(params: {
+  provider: string;
+  apiKey?: string;
+  baseURL?: string;
+  subPlatform?: string;
+  apiType?: string;
+  modelID?: string;
+  customPreset?: string;
+  proxyPort?: number;
+}): Promise<boolean> {
+  const { provider, apiKey, baseURL, subPlatform, apiType, modelID, customPreset, proxyPort } = params;
+
+  // 确定实际的 API 类型和 base URL
+  let effectiveApi: string;
+  let effectiveBase: string;
+
+  if (provider === "anthropic") {
+    effectiveApi = "anthropic-messages";
+    effectiveBase = PROVIDER_PRESETS.anthropic.baseUrl;
+  } else if (provider === "openai") {
+    effectiveApi = "openai-completions";
+    effectiveBase = PROVIDER_PRESETS.openai.baseUrl;
+  } else if (provider === "google") {
+    // Google Generative AI 验证走 /models 端点，不走 chat，且主流模型均支持图片
+    return true;
+  } else if (provider === "moonshot") {
+    if (subPlatform === "kimi-code") {
+      effectiveApi = "anthropic-messages";
+      effectiveBase = `http://127.0.0.1:${proxyPort}/coding`;
+    } else {
+      const sub = MOONSHOT_SUB_PLATFORMS[subPlatform || "moonshot-cn"] || MOONSHOT_SUB_PLATFORMS["moonshot-cn"];
+      effectiveApi = sub.api;
+      effectiveBase = sub.baseUrl;
+    }
+  } else if (provider === "custom") {
+    const customPre = customPreset ? CUSTOM_PROVIDER_PRESETS[customPreset] : undefined;
+    effectiveBase = (baseURL || (customPre ? customPre.baseUrl : ""))!.replace(/\/$/, "");
+    effectiveApi = customPre ? customPre.api : (apiType || "openai-completions");
+  } else {
+    // feishu/qqbot/dingtalk 等无 chat 接口的 provider — 默认不支持
+    return false;
+  }
+
+  if (!effectiveBase || !modelID) return true; // 无法探测时保守返回 true
+
+  try {
+    if (effectiveApi === "anthropic-messages") {
+      const url = effectiveBase.replace(/\/$/, "") + "/v1/messages";
+      const headers: Record<string, string> = {
+        "User-Agent": UA_ANTHROPIC,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      };
+      // kimi-code 走代理无需 x-api-key；其他需要
+      if (apiKey && provider !== "moonshot") headers["x-api-key"] = apiKey;
+      if (provider === "moonshot" && subPlatform !== "kimi-code" && apiKey) headers["x-api-key"] = apiKey;
+
+      await jsonRequest(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          model: modelID,
+          max_tokens: 1,
+          messages: [{
+            role: "user",
+            content: [
+              { type: "image", source: { type: "base64", media_type: "image/png", data: TINY_PNG_B64 } },
+              { type: "text", text: "hi" },
+            ],
+          }],
+        }),
+      });
+      return true;
+    } else if (effectiveApi === "openai-completions") {
+      const url = effectiveBase.replace(/\/$/, "") + "/chat/completions";
+      await jsonRequest(url, {
+        method: "POST",
+        headers: {
+          "User-Agent": UA_OPENAI,
+          Authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: modelID,
+          max_tokens: 1,
+          messages: [{
+            role: "user",
+            content: [
+              { type: "image_url", image_url: { url: `data:image/png;base64,${TINY_PNG_B64}` } },
+              { type: "text", text: "hi" },
+            ],
+          }],
+        }),
+      });
+      return true;
+    }
+    // openai-responses / google-generative-ai 等不易探测，保守返回 true
+    return true;
+  } catch {
+    // 请求失败说明模型不支持图片
+    return false;
+  }
+}
+
 // ── 统一验证入口（根据 provider 名称分派） ──
 
 export async function verifyProvider(params: {
@@ -447,7 +560,7 @@ export async function verifyProvider(params: {
   clientSecret?: string;
   customPreset?: string;
   proxyPort?: number;
-}): Promise<{ success: boolean; message?: string }> {
+}): Promise<{ success: boolean; message?: string; supportsImage?: boolean }> {
   const {
     provider,
     apiKey,
@@ -501,7 +614,11 @@ export async function verifyProvider(params: {
       default:
         return { success: false, message: `未知 Provider: ${provider}` };
     }
-    return { success: true };
+
+    // 文本验证通过后，自动探测图片能力
+    const supportsImage = await probeImageSupport(params);
+
+    return { success: true, supportsImage };
   } catch (err: any) {
     return { success: false, message: err.message || String(err) };
   }

--- a/src/settings-ipc.ts
+++ b/src/settings-ipc.ts
@@ -30,6 +30,7 @@ import {
   readUserConfig,
   writeUserConfig,
 } from "./provider-config";
+import { getModelInput } from "./model-catalog";
 import { getLatestShareCopyPayload } from "./share-copy";
 import { readSkillStoreRegistry, writeSkillStoreRegistry } from "./skill-store";
 import {
@@ -500,7 +501,9 @@ export function registerSettingsIpc(opts: SettingsIpcOptions = {}): void {
                 return id === modelID;
               });
               if (!hasModel) {
-                existingProv.models.push({ id: modelID, name: modelID, input: ["text", "image"] });
+                const catalogInput = getModelInput(provKey, modelID);
+                const modelInput = catalogInput ?? ["text", "image"];
+                existingProv.models.push({ id: modelID, name: modelID, input: modelInput });
               }
             } else {
               // provider 不存在 → 用 saveMoonshotConfig 创建


### PR DESCRIPTION
## Summary
- 移除 Setup 和 Settings 页面的「模型支持图片输入」手动 checkbox
- 新增 `model-catalog.ts`：启动时调用 `openclaw models list --all --json`，缓存 ~800 个模型的 `input` 能力
- `buildProviderConfig` / `saveMoonshotConfig` / Settings model append 均改用 catalog 查询，替代原来的硬编码 `["text", "image"]`
- 删除 `probeImageSupport` 运行时探测（存在 Anthropic URL 拼错、错误吞并等问题）
- `verifyProvider` 回归纯文本验证，不再发额外 HTTP 请求

解决用户配置了不支持图片的模型（如 MiniMax-M2.5）时被错误标记为 `input: ["text", "image"]` 导致使用报错的问题。根因是 `buildProviderConfig` 对 Custom 预设硬编码了图片能力，而 openclaw 官方目录已精确标注 MiniMax-M2.5 为 `input: ["text"]`。

## Changes
- `src/model-catalog.ts`（新增）：`loadModelCatalog()` + `getModelInput(providerKey, modelId)` — 启动后台加载，同步查询
- `src/provider-config.ts`：删除 `probeImageSupport`（~100 行），`buildProviderConfig` / `saveMoonshotConfig` 用 catalog 替代硬编码
- `src/settings-ipc.ts`：Moonshot model append 路径同步改用 catalog
- `src/main.ts`：`app.whenReady()` 中后台调 `loadModelCatalog()`
- `setup/index.html` + `setup/setup.js`：移除 imageSupport checkbox
- `settings/index.html` + `settings/settings.js`：移除 supportImage checkbox

## Design
- **有 catalog 命中**（minimax/anthropic/openai/google/moonshot/zai 等 ~800 模型）→ 用 openclaw 权威数据
- **无 catalog 命中**（volcengine/qwen/deepseek/真正未知模型）→ 回退到 `supportImage` 参数或默认 `["text", "image"]`
- Provider key 别名映射：`zai-global` / `zai-cn` → openclaw 的 `zai`
- Catalog 加载失败时静默降级，不影响任何现有功能

## Test plan
- [x] TypeScript 编译通过
- [x] dev:isolated 启动日志确认 `[model-catalog] loaded 792 models`
- [x] 单元验证 `getModelInput("minimax", "MiniMax-M2.5")` → `["text"]`
- [x] 单元验证 `getModelInput("zai-global", "glm-5")` → `["text"]`（别名）
- [x] 单元验证 `getModelInput("volcengine", "doubao-seed-2.0-pro")` → `undefined`（fallback）
- [ ] Setup 流程：配置 MiniMax-M2.5 → 确认写入 `input: ["text"]`
- [ ] Setup 流程：配置 Claude → 确认写入 `input: ["text", "image"]`
- [ ] Settings 添加模型：custom 手动模式不再显示 checkbox
- [ ] 确认 Setup/Settings 页面 checkbox 已消失

🤖 Generated with [Claude Code](https://claude.com/claude-code)