### PR TITLE
fix(chat-ui): unstick stop button when gateway stalls mid-run

### DIFF
--- a/chat-ui/ui/src/ui/app.ts
+++ b/chat-ui/ui/src/ui/app.ts
@@ -455,6 +455,7 @@ export class OpenClawApp extends LitElement {
   chatPendingStreamText: string | null = null;
   chatStreamFrame: number | null = null;
   chatRunId: string | null = null;
+  chatAbortedRunId: string | null = null;
   compactionStatus: CompactionStatus | null = null;
   chatAvatarUrl: string | null = null;
   chatThinkingLevel: string | null = null;

--- a/chat-ui/ui/src/ui/controllers/chat.test.ts
+++ b/chat-ui/ui/src/ui/controllers/chat.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { handleChatEvent, loadChatHistory } from "./chat.ts";
+import { abortChatRun, handleChatEvent, loadChatHistory } from "./chat.ts";
 
 type RafTask = {
   id: number;
@@ -67,6 +67,7 @@ function makeState(overrides: Record<string, unknown> = {}) {
     chatHistoryHydrationFrame: null,
     chatPendingStreamText: null,
     chatStreamFrame: null,
+    chatAbortedRunId: null,
     lastError: null,
     ...overrides,
   } as any;
@@ -131,9 +132,58 @@ async function testLoadChatHistoryBatchesInitialRender() {
   assert.equal(state.chatVisibleMessageCount, 80, "渐进渲染结束后应补齐全部历史消息");
 }
 
+// feedback #391：gateway 在工具调用卡死时可能永远不发 final/error 事件；
+// 用户点停止后，本地 streaming 状态必须立即解除，且迟到的 delta 不能把它重新拉回来。
+async function testAbortImmediatelyClearsStreamAndIgnoresLateDeltas() {
+  const raf = new FakeRaf();
+  installBrowserGlobals(raf);
+  let abortRequested = false;
+  const state = makeState({
+    client: {
+      // 模拟 gateway 挂死：chat.abort 永远不返回
+      request: (method: string) => {
+        if (method === "chat.abort") {
+          abortRequested = true;
+          return new Promise(() => {});
+        }
+        return Promise.resolve({});
+      },
+    },
+    chatRunId: "run-stuck",
+    chatStream: "任务处理中…",
+    chatStreamStartedAt: 0,
+  });
+
+  // abort 不等 RPC 返回，直接立刻解冻，不 await
+  const abortPromise = abortChatRun(state);
+
+  // 微任务让 abort 内部完成本地清流
+  await flushMicrotasks();
+
+  assert.equal(abortRequested, true, "abort 应发出 chat.abort RPC");
+  assert.equal(state.chatRunId, null, "abort 后 chatRunId 必须立刻清空");
+  assert.equal(state.chatStream, null, "abort 后 streaming 文本必须立刻清空");
+  assert.equal(state.chatAbortedRunId, "run-stuck", "abort 后应记下待忽略的旧 runId");
+
+  // 模拟 gateway 迟到的 delta：不应把 stream 重新激活
+  handleChatEvent(state, {
+    runId: "run-stuck",
+    sessionKey: "session-1",
+    state: "delta",
+    message: { role: "assistant", content: [{ type: "text", text: "迟到的回复" }] },
+  });
+  raf.runAll();
+  assert.equal(state.chatStream, null, "abort 后，旧 run 的 delta 不得重新开启 streaming");
+  assert.equal(state.chatRunId, null, "abort 后，旧 run 的事件不得恢复 chatRunId");
+
+  // 不 await abortPromise：它永远 pending（RPC 超时后 reject，与本测试无关）
+  void abortPromise;
+}
+
 async function main() {
   await testChatStreamIsRafThrottled();
   await testLoadChatHistoryBatchesInitialRender();
+  await testAbortImmediatelyClearsStreamAndIgnoresLateDeltas();
   console.log("chat controller tests passed");
 }
 

--- a/chat-ui/ui/src/ui/controllers/chat.ts
+++ b/chat-ui/ui/src/ui/controllers/chat.ts
@@ -46,6 +46,10 @@ export type ChatState = {
   chatHistoryHydrationFrame: number | null;
   chatPendingStreamText: string | null;
   chatStreamFrame: number | null;
+  // 记录最近一次被用户本地 abort 的 runId：gateway 在卡死或重启前可能仍会把
+  // 旧 run 的 delta/final 事件陆续推回，这里用它来幂等丢弃，避免 stop 之后
+  // UI 又被旧事件重新拉回 streaming 状态。
+  chatAbortedRunId: string | null;
   lastError: string | null;
 };
 
@@ -223,6 +227,9 @@ export async function sendChatMessage(
   state.chatRunId = runId;
   state.chatStream = "";
   state.chatStreamStartedAt = now;
+  // 发新消息意味着上一轮本地 abort 的 run 已彻底不相关，清掉旧 runId 避免影响未来判断。
+  state.chatAbortedRunId = null;
+  state.chatPendingStreamText = null;
 
   // 只有图片附件走 base64 API，文件路径已拼入消息文本
   const apiAttachments = hasImages
@@ -272,18 +279,44 @@ export async function sendChatMessage(
   }
 }
 
+// 见 feedback #391：gateway 在工具调用卡死（或嵌套 agent.wait 超时）时，
+// 可能永远不会发 final/error 事件。此时前端靠等 gateway 返回来解冻是没希望的。
+// 策略：点停止后立刻本地清流，让 UI 恢复响应；chat.abort RPC 再在后台尽力发送，
+// 短超时避免悬挂；已终止 run 的后续事件由 chatAbortedRunId 幂等丢弃。
+const CHAT_ABORT_RPC_TIMEOUT_MS = 3000;
+
 export async function abortChatRun(state: ChatState): Promise<boolean> {
   if (!state.client || !state.connected) {
     return false;
   }
   const runId = state.chatRunId;
+  // 先记下待忽略的 runId，再清流；顺序重要：清流会把 chatRunId 置 null。
+  if (runId) {
+    state.chatAbortedRunId = runId;
+  }
+  resetChatStreamState(state);
   try {
-    await state.client.request(
+    const request = state.client.request(
       "chat.abort",
       runId ? { sessionKey: state.sessionKey, runId } : { sessionKey: state.sessionKey },
     );
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error("chat.abort timed out")),
+        CHAT_ABORT_RPC_TIMEOUT_MS,
+      );
+    });
+    try {
+      await Promise.race([request, timeout]);
+    } finally {
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+    }
     return true;
   } catch (err) {
+    // RPC 失败或超时不回滚本地状态：用户已经选择停止，UI 必须保持可用。
     state.lastError = String(err);
     return false;
   }
@@ -294,6 +327,15 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     return null;
   }
   if (payload.sessionKey !== state.sessionKey) {
+    return null;
+  }
+
+  // 用户已本地 abort 过的 run：丢弃其后续事件，避免 delta 把 stream 状态重新拉起来。
+  // final 仍往上抛，方便调用方刷新历史（抛到的是对应路径），但不再驱动本 session 的 stream。
+  if (payload.runId && state.chatAbortedRunId && payload.runId === state.chatAbortedRunId) {
+    if (payload.state === "final") {
+      return "final";
+    }
     return null;
   }
 


### PR DESCRIPTION
## Summary

- Addresses feedback #391: gateway's `agent.wait` 600s timeout path can surface an internal error without emitting any terminal WebSocket event, leaving the UI stuck in "thinking" and the stop button unresponsive.
- Frontend-only fix: clicking stop now clears local streaming state immediately; the `chat.abort` RPC races a 3s timeout in the background and never blocks the UI.
- `chatAbortedRunId` guards against late deltas/finals from a stuck run reviving the cleared stream after the user has stopped.

## Why split from #391's other changes

The tool-events rendering alignment is a separate concern (see companion PR `feat/chat-stream-tool-events`). This PR is the pure abort-unstick fix and can ship independently.

## Test plan

- [x] Unit test `testAbortImmediatelyClearsStreamAndIgnoresLateDeltas` passes
- [x] `npm run build:chat` succeeds
- [ ] Manual: trigger a long tool call, click stop, verify UI unfreezes instantly and new messages work
- [ ] Manual: simulate gateway hang (kill gateway process mid-run) → stop button still clears UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)