### PR TITLE
feat(chat-ui): stream intermediate tool calls like openclaw-control-ui

### DIFF
--- a/chat-ui/ui/src/ui/app-tool-stream.ts
+++ b/chat-ui/ui/src/ui/app-tool-stream.ts
@@ -13,6 +13,11 @@ export type AgentEventPayload = {
   data: Record<string, unknown>;
 };
 
+// 每次新 tool call 到来时，把当前在打字的 assistant 文本冻结成一段，挂在这条 tool entry 上。
+// 这样渲染时能按"上一段文本 → tool call → tool result → 下一段文本 …"的时间序展开，
+// 与 gateway 写进 transcript 的消息形态保持一致（history 加载后也是这样分开展示）。
+export type StreamSegment = { text: string; ts: number };
+
 export type ToolStreamEntry = {
   toolCallId: string;
   runId: string;
@@ -22,7 +27,12 @@ export type ToolStreamEntry = {
   output?: string;
   startedAt: number;
   updatedAt: number;
-  message: Record<string, unknown>;
+  // 该 tool 之前冻结下来的 assistant 文本（若有）。只会设一次，就在 entry 创建那一刻。
+  leadingSegment?: StreamSegment;
+  // 分成两条 message：call 走 assistant 气泡 + 内联 tool 卡，result 走独立的 toolResult 气泡。
+  // 和 history 里的消息形态完全一致，复用同一套 renderGroupedMessage 分支。
+  callMessage: Record<string, unknown>;
+  resultMessage?: Record<string, unknown>;
 };
 
 type ToolStreamHost = {
@@ -30,8 +40,14 @@ type ToolStreamHost = {
   chatRunId: string | null;
   toolStreamById: Map<string, ToolStreamEntry>;
   toolStreamOrder: string[];
+  // 已摊平的时间线：segment text / call msg / result msg 混合，供渲染直接 iterate。
   chatToolMessages: Record<string, unknown>[];
   toolStreamSyncTimer: number | null;
+  // 当前在打字的 assistant 文本（尚未被任何 tool call 触发冻结，只有这一段闪红光）
+  chatStream: string | null;
+  chatStreamStartedAt: number | null;
+  // handleChatEvent delta 走 raf 节流，pending 是下一帧要写进 chatStream 的值
+  chatPendingStreamText: string | null;
 };
 
 function extractToolOutputText(value: unknown): string | null {
@@ -92,26 +108,33 @@ function formatToolOutput(value: unknown): string | null {
   return `${truncated.text}\n\n… truncated (${truncated.total} chars, showing first ${truncated.text.length}).`;
 }
 
-function buildToolStreamMessage(entry: ToolStreamEntry): Record<string, unknown> {
-  const content: Array<Record<string, unknown>> = [];
-  content.push({
-    type: "toolcall",
-    name: entry.name,
-    arguments: entry.args ?? {},
-  });
-  if (entry.output) {
-    content.push({
-      type: "toolresult",
-      name: entry.name,
-      text: entry.output,
-    });
-  }
+// 构造 assistant 侧的 tool call 消息：**不挂 toolCallId 到顶层**。
+// 挂了的话 normalizeMessage 会把它归类成 toolResult，渲染走无气泡的 renderCollapsedToolCards 路径；
+// 不挂则 role 保持 assistant → 走正常气泡分支，tool card 以折叠形式嵌在气泡里（和 history 一致）。
+function buildToolCallMessage(entry: ToolStreamEntry): Record<string, unknown> {
   return {
     role: "assistant",
+    runId: entry.runId,
+    content: [
+      {
+        type: "toolCall",
+        id: entry.toolCallId,
+        name: entry.name,
+        arguments: entry.args ?? {},
+      },
+    ],
+    timestamp: entry.startedAt,
+  };
+}
+
+// 构造 toolResult 消息：走 role=toolResult 路径，自成一个 group，渲染为独立的 "Tool output" 气泡。
+function buildToolResultMessage(entry: ToolStreamEntry): Record<string, unknown> {
+  return {
+    role: "toolResult",
     toolCallId: entry.toolCallId,
     runId: entry.runId,
-    content,
-    timestamp: entry.startedAt,
+    content: [{ type: "text", text: entry.output ?? "" }],
+    timestamp: entry.updatedAt,
   };
 }
 
@@ -127,9 +150,26 @@ function trimToolStream(host: ToolStreamHost) {
 }
 
 function syncToolStreamMessages(host: ToolStreamHost) {
-  host.chatToolMessages = host.toolStreamOrder
-    .map((id) => host.toolStreamById.get(id)?.message)
-    .filter((msg): msg is Record<string, unknown> => Boolean(msg));
+  // 摊平成时间线：每条 entry 依次贡献 leadingSegment（若有）→ callMessage → resultMessage（若已出）
+  const out: Record<string, unknown>[] = [];
+  for (const id of host.toolStreamOrder) {
+    const entry = host.toolStreamById.get(id);
+    if (!entry) {
+      continue;
+    }
+    if (entry.leadingSegment && entry.leadingSegment.text.trim().length > 0) {
+      out.push({
+        role: "assistant",
+        content: [{ type: "text", text: entry.leadingSegment.text }],
+        timestamp: entry.leadingSegment.ts,
+      });
+    }
+    out.push(entry.callMessage);
+    if (entry.resultMessage) {
+      out.push(entry.resultMessage);
+    }
+  }
+  host.chatToolMessages = out;
 }
 
 export function flushToolStreamSync(host: ToolStreamHost) {
@@ -251,6 +291,19 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   const now = Date.now();
   let entry = host.toolStreamById.get(toolCallId);
   if (!entry) {
+    // 新 tool call：把当前 live 的 assistant 文本冻结下来作为这条 entry 的 leadingSegment。
+    // 优先 pending（raf 队列里尚未 flush 的最新值），否则用已可见的 chatStream。
+    const pending = host.chatPendingStreamText;
+    const live = host.chatStream;
+    const liveText = (pending ?? live ?? "").trim().length > 0 ? (pending ?? live) : null;
+    const leading: StreamSegment | undefined = liveText
+      ? { text: liveText, ts: host.chatStreamStartedAt ?? now }
+      : undefined;
+    if (leading) {
+      host.chatStream = null;
+      host.chatStreamStartedAt = null;
+      host.chatPendingStreamText = null;
+    }
     entry = {
       toolCallId,
       runId: payload.runId,
@@ -260,8 +313,13 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
       output: output || undefined,
       startedAt: typeof payload.ts === "number" ? payload.ts : now,
       updatedAt: now,
-      message: {},
+      leadingSegment: leading,
+      callMessage: {},
     };
+    entry.callMessage = buildToolCallMessage(entry);
+    if (entry.output !== undefined) {
+      entry.resultMessage = buildToolResultMessage(entry);
+    }
     host.toolStreamById.set(toolCallId, entry);
     host.toolStreamOrder.push(toolCallId);
   } else {
@@ -273,9 +331,16 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
       entry.output = output || undefined;
     }
     entry.updatedAt = now;
+    // 名称/参数变更要反映到 call 消息，但保留其 timestamp（start 时钉住）。
+    entry.callMessage = {
+      ...buildToolCallMessage(entry),
+      timestamp: entry.callMessage.timestamp ?? entry.startedAt,
+    };
+    if (entry.output !== undefined) {
+      entry.resultMessage = buildToolResultMessage(entry);
+    }
   }
 
-  entry.message = buildToolStreamMessage(entry);
   trimToolStream(host);
   scheduleToolStreamSync(host, phase === "result");
 }

--- a/chat-ui/ui/src/ui/gateway.ts
+++ b/chat-ui/ui/src/ui/gateway.ts
@@ -1,5 +1,6 @@
 import { buildDeviceAuthPayload } from "../../../src/gateway/device-auth.js";
 import {
+  GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
   type GatewayClientMode,
@@ -270,7 +271,10 @@ export class GatewayBrowserClient {
       role,
       scopes,
       device,
-      caps: [],
+      // 声明 tool-events：gateway 只给带此 cap 的客户端推送 tool call/result 流。
+      // 不声明则 chat 消息列表只有最终 assistant 文本，看不到中间的多轮 tool 调用。
+      // 对照：openclaw 自带的 control-ui bundle 默认声明 ['tool-events']。
+      caps: [GATEWAY_CLIENT_CAPS.TOOL_EVENTS],
       auth,
       userAgent: navigator.userAgent,
       locale: navigator.language,

--- a/chat-ui/ui/src/ui/views/chat.ts
+++ b/chat-ui/ui/src/ui/views/chat.ts
@@ -690,6 +690,9 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
       message: msg,
     });
   }
+  // toolMessages 本身是摊平的时间线（由 app-tool-stream.ts::syncToolStreamMessages 构造）：
+  // 依次包含 leadingSegment 文本 / tool call / tool result，作为普通 message 追加即可，
+  // groupMessages 会按 role 自动分组成和 history 一致的 "assistant 文本+call → toolResult" 节奏。
   if (props.showThinking) {
     for (let i = 0; i < tools.length; i++) {
       items.push({


### PR DESCRIPTION
## Summary

- During streaming, OneClaw chat UI only showed the first assistant bubble flashing red and hid all subsequent tool calls until completion. openclaw-control-ui renders them live — comparison exposed two gaps.
- Gap 1: handshake never declared the `tool-events` capability, so gateway withheld per-tool `start/update/result` events from us.
- Gap 2: even if events arrived, the streaming path merged call + result into a single message with `toolCallId` at top level, which the message normalizer promoted to `role=toolResult`, causing the renderer to drop the bubble frame around the tool card.

## Changes

- `gateway.ts`: advertise `GATEWAY_CLIENT_CAPS.TOOL_EVENTS` on connect.
- `app-tool-stream.ts`: redesign `ToolStreamEntry` to match how transcripts persist history. Each entry now splits into `leadingSegment` (frozen assistant prose captured at tool start, so earlier text stops flashing red), `callMessage` (role=assistant with toolCall content → keeps bubble frame), and `resultMessage` (role=toolResult → its own bubble). `syncToolStreamMessages` flattens the timeline so `groupMessages` re-groups it identically to loaded history.
- `views/chat.ts`: append the flattened timeline directly; comment explains grouping.

## Restored behaviors (previously only visible in openclaw-control-ui)

- Only the live streaming segment flashes red; locked-in prose renders as a plain bubble.
- Tool call cards render inside a chat bubble frame (same as history view).
- Multiple assistant turns in one run display as separate bubbles rather than being merged into one.

## Relation to companion PR

Independent of #74 (abort unstick). Both fix symptoms from feedback #391 but neither depends on the other.

## Test plan

- [x] `npm run build:chat` succeeds
- [ ] Manual: send a task that triggers multiple tool calls; verify each call appears in its own bubble as it executes, with the result bubble following
- [ ] Manual: verify the live-typing segment is the only one flashing red
- [ ] Manual: load a completed conversation from history and verify visual parity with streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)