### PR TITLE
fix(providers): remove deepseek-v4-flash from preset

### DIFF
--- a/settings/settings.js
+++ b/settings/settings.js
@@ -108,7 +108,7 @@
     "deepseek": {
       providerKey: "deepseek",
       placeholder: "sk-...",
-      models: ["deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"],
+      models: ["deepseek-chat", "deepseek-reasoner"],
     },
   };
 

--- a/setup/setup.js
+++ b/setup/setup.js
@@ -100,7 +100,7 @@
     "deepseek": {
       providerKey: "deepseek",
       placeholder: "sk-...",
-      models: ["deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"],
+      models: ["deepseek-chat", "deepseek-reasoner"],
     },
   };
 

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -101,7 +101,7 @@ export const CUSTOM_PROVIDER_PRESETS: Record<string, CustomProviderPreset> = {
     baseUrl: "https://api.deepseek.com",
     api: "openai-completions",
     placeholder: "sk-...",
-    models: ["deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"],
+    models: ["deepseek-chat", "deepseek-reasoner"],
   },
 };
 


### PR DESCRIPTION
## Summary

PR #82 squash-merged the addition of `deepseek-v4-flash` to the DeepSeek dropdown without the follow-up revert commit, so main currently advertises a model the gateway can't talk to. This PR rolls `deepseek` back to `[deepseek-chat, deepseek-reasoner]`.

`volcengine-coding` keeps `deepseek-v3.2` unchanged — that aggregator entry goes through Ark, not DeepSeek's own API, and is not affected.

## Test plan

- [x] \`tsc --noEmit\` passes
- [ ] Verify Settings → Provider → DeepSeek dropdown no longer lists \`deepseek-v4-flash\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)