### PR TITLE
fix(channels): sync plugins.allow when enabling qqbot

### DIFF
--- a/src/qqbot-config.test.ts
+++ b/src/qqbot-config.test.ts
@@ -40,6 +40,42 @@ test("saveQqbotConfig 启用时应写入插件开关并保留 allowFrom", () => 
   assert.equal("clientSecretFile" in config.channels.qqbot, false);
 });
 
+test("saveQqbotConfig 启用时应将 qqbot 追加到非空 plugins.allow", () => {
+  const config: Record<string, any> = {
+    plugins: {
+      allow: ["wecom-openclaw-plugin"],
+      entries: {},
+    },
+    channels: {},
+  };
+
+  saveQqbotConfig(config, {
+    enabled: true,
+    appId: "1024",
+    clientSecret: "secret-1",
+  });
+
+  assert.deepEqual(config.plugins.allow, ["wecom-openclaw-plugin", "qqbot"]);
+});
+
+test("saveQqbotConfig 重复启用时不应在 plugins.allow 中产生重复项", () => {
+  const config: Record<string, any> = {
+    plugins: {
+      allow: ["wecom-openclaw-plugin", "qqbot"],
+      entries: {},
+    },
+    channels: {},
+  };
+
+  saveQqbotConfig(config, {
+    enabled: true,
+    appId: "1024",
+    clientSecret: "secret-1",
+  });
+
+  assert.deepEqual(config.plugins.allow, ["wecom-openclaw-plugin", "qqbot"]);
+});
+
 test("saveQqbotConfig 禁用时应保留凭据并仅关闭开关", () => {
   // 禁用不应抹掉用户已保存的 QQ 凭据，便于再次启用。
   const config: Record<string, any> = {

--- a/src/qqbot-config.ts
+++ b/src/qqbot-config.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { resolveGatewayPackageDir } from "./constants";
+import { syncPluginAllowOnEnable } from "./kimi-config";
 
 export const QQBOT_PLUGIN_ID = "qqbot";
 
@@ -87,6 +88,8 @@ export function saveQqbotConfig(config: any, params: SaveQqbotConfigParams): voi
     };
     return;
   }
+
+  syncPluginAllowOnEnable(config, QQBOT_PLUGIN_ID);
 
   config.channels[QQBOT_PLUGIN_ID] = {
     ...existingChannel,


### PR DESCRIPTION
目标
修复在已有其他远程渠道(已触发 extension-mirror reconcile 写入
plugins.allow)的情况下,启用 QQ 机器人后回复仍出现"该机器人的灵魂不在线"的问题。

背景
openclaw 的 config-state 在 plugins.allow非空时执行严格白名单:未列入的插件会被
静默降级为enabled:false(cause:"not-in-allowlist"),即使 entries.qqbot.enabled=true。
register()仍会成功(账号能登录 QQ),但每账号渠道生命周期不会启动,消息直接回退到占位文案。

主要改动
-   src/qqbot-config.ts:在 saveQqbotConfig 启用分支调用 syncPluginAllowOnEnable,与
     dingtalk-config.ts、kimi-config.ts 等同类渠道保持一致。
-  src/qqbot-config.test.ts:新增两个回归测试