### PR TITLE
feat(kimi-usage): restore panel with refresh + dynamic window labels

### DIFF
--- a/chat-ui/ui/src/ui/i18n.ts
+++ b/chat-ui/ui/src/ui/i18n.ts
@@ -423,6 +423,8 @@ const dict: Record<Locale, Record<string, string>> = {
     "settings.provider.usage.rateLimit": "速率限制",
     "settings.provider.usage.refresh": "刷新",
     "settings.provider.usage.resetIn": "重置于",
+    "settings.provider.usage.hourUsage": "{n} 小时用量",
+    "settings.provider.usage.minuteUsage": "{n} 分钟用量",
 
     // Setup
     "setup.provider.apiKey": "API Key",
@@ -986,6 +988,8 @@ const dict: Record<Locale, Record<string, string>> = {
     "settings.provider.usage.rateLimit": "Rate Limit",
     "settings.provider.usage.refresh": "Refresh",
     "settings.provider.usage.resetIn": "Resets in",
+    "settings.provider.usage.hourUsage": "{n}h usage",
+    "settings.provider.usage.minuteUsage": "{n}m usage",
 
     // Setup
     "setup.provider.apiKey": "API Key",

--- a/chat-ui/ui/src/ui/views/settings/tab-provider-usage.lib.ts
+++ b/chat-ui/ui/src/ui/views/settings/tab-provider-usage.lib.ts
@@ -1,0 +1,185 @@
+/**
+ * Pure derivation for the Kimi usage panel rendered in the Provider tab.
+ * Kept free of Lit / DOM imports so node:test can exercise it directly.
+ */
+
+export type Locale = "zh" | "en";
+
+export interface UsageLabels {
+  rateFallback: string;   // "速率限制" / "Rate Limit"
+  hourUsage: string;      // "{n} 小时用量" / "{n}h usage"
+  minuteUsage: string;    // "{n} 分钟用量" / "{n}m usage"
+}
+
+export interface UsageCardView {
+  title: string;
+  pct: number;            // 0-100 for the progress bar width
+  pctText: string;        // "48%"
+  rawText: string;        // "480 / 1000" — used as tooltip
+  resetText: string;      // "5小时后重置" / "5h reset" / "" when no reset info
+}
+
+export interface UsageView {
+  week: UsageCardView | null;
+  rate: UsageCardView | null;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+function toInt(v: unknown): number {
+  if (typeof v === "number" && Number.isFinite(v)) return Math.trunc(v);
+  if (typeof v === "string") {
+    const n = parseInt(v, 10);
+    return Number.isFinite(n) ? n : 0;
+  }
+  return 0;
+}
+
+function parseResetAt(val: unknown): number {
+  if (typeof val !== "string" || !val) return 0;
+  try {
+    let str = val;
+    // Trim sub-millisecond precision the Date constructor doesn't accept.
+    if (str.includes(".") && str.endsWith("Z")) {
+      const parts = str.slice(0, -1).split(".");
+      str = parts[0] + "." + parts[1].slice(0, 3) + "Z";
+    }
+    const dt = new Date(str);
+    const diff = (dt.getTime() - Date.now()) / 1000;
+    return diff > 0 ? Math.round(diff) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function parseResetSeconds(data: unknown): number {
+  if (!isRecord(data)) return 0;
+  const timestamps = ["reset_at", "resetAt", "reset_time", "resetTime"];
+  for (const k of timestamps) {
+    const v = data[k];
+    if (typeof v === "string" && v) return parseResetAt(v);
+  }
+  const durations = ["reset_in", "resetIn", "ttl", "window"];
+  for (const k of durations) {
+    const raw = data[k];
+    if (typeof raw === "number" || typeof raw === "string") {
+      const v = toInt(raw);
+      if (v > 0) return v;
+    }
+  }
+  return 0;
+}
+
+export function formatResetText(seconds: number, locale: Locale): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const isZh = locale === "zh";
+  if (h > 0) return h + (isZh ? "小时后重置" : "h reset");
+  if (m > 0) return m + (isZh ? "分钟后重置" : "m reset");
+  return isZh ? "即将重置" : "resetting soon";
+}
+
+interface WindowMeta {
+  duration: number;
+  timeUnit: string;
+}
+
+function readWindowMeta(item: unknown): WindowMeta | null {
+  if (!isRecord(item)) return null;
+  // Priority: limits[0].window → limits[0].detail.window → limits[0] → limits[0].detail
+  const detail = isRecord(item.detail) ? (item.detail as Record<string, unknown>) : null;
+  const sources: Array<Record<string, unknown> | null> = [
+    isRecord(item.window) ? (item.window as Record<string, unknown>) : null,
+    detail && isRecord(detail.window) ? (detail.window as Record<string, unknown>) : null,
+    item,
+    detail,
+  ];
+  for (const src of sources) {
+    if (!src) continue;
+    const duration = toInt(src.duration);
+    const timeUnit = typeof src.timeUnit === "string" ? src.timeUnit : "";
+    if (duration > 0 && timeUnit) return { duration, timeUnit };
+  }
+  return null;
+}
+
+function applyTemplate(template: string, value: number): string {
+  return template.replace(/\{n\}/g, String(value));
+}
+
+export function computeRateWindowLabel(
+  limits: unknown,
+  locale: Locale,
+  labels: UsageLabels,
+): string {
+  if (!Array.isArray(limits) || limits.length === 0) return labels.rateFallback;
+  const meta = readWindowMeta(limits[0]);
+  if (!meta) return labels.rateFallback;
+
+  const unit = meta.timeUnit.toUpperCase();
+  if (unit.includes("MINUTE")) {
+    if (meta.duration % 60 === 0) {
+      return applyTemplate(labels.hourUsage, meta.duration / 60);
+    }
+    return applyTemplate(labels.minuteUsage, meta.duration);
+  }
+  if (unit.includes("HOUR")) {
+    return applyTemplate(labels.hourUsage, meta.duration);
+  }
+  return labels.rateFallback;
+}
+
+function deriveUsedLimit(source: Record<string, unknown>): { used: number; limit: number } {
+  const limit = toInt(source.limit);
+  const usedRaw = source.used;
+  if (usedRaw !== undefined && usedRaw !== null && usedRaw !== "") {
+    return { used: toInt(usedRaw), limit };
+  }
+  const remaining = source.remaining;
+  if (remaining !== undefined && remaining !== null && remaining !== "") {
+    return { used: Math.max(0, limit - toInt(remaining)), limit };
+  }
+  return { used: 0, limit };
+}
+
+function buildCard(
+  source: Record<string, unknown>,
+  title: string,
+  locale: Locale,
+): UsageCardView {
+  const { used, limit } = deriveUsedLimit(source);
+  const pct = limit > 0
+    ? Math.min(100, Math.max(0, Math.round((used / limit) * 100)))
+    : 0;
+  return {
+    title,
+    pct,
+    pctText: `${pct}%`,
+    rawText: `${used} / ${limit}`,
+    resetText: formatResetText(parseResetSeconds(source), locale),
+  };
+}
+
+export function deriveUsageView(
+  data: unknown,
+  locale: Locale,
+  labels: UsageLabels,
+): UsageView {
+  if (!isRecord(data)) return { week: null, rate: null };
+
+  const weekSource = isRecord(data.usage) ? (data.usage as Record<string, unknown>) : null;
+  const week = weekSource ? buildCard(weekSource, "", locale) : null;
+
+  const limits = Array.isArray(data.limits) ? data.limits : [];
+  let rate: UsageCardView | null = null;
+  if (limits.length > 0 && isRecord(limits[0])) {
+    const item = limits[0] as Record<string, unknown>;
+    const detail = isRecord(item.detail) ? (item.detail as Record<string, unknown>) : item;
+    rate = buildCard(detail, computeRateWindowLabel(limits, locale, labels), locale);
+  }
+
+  return { week, rate };
+}

--- a/chat-ui/ui/src/ui/views/settings/tab-provider-usage.test.ts
+++ b/chat-ui/ui/src/ui/views/settings/tab-provider-usage.test.ts
@@ -1,0 +1,216 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  computeRateWindowLabel,
+  deriveUsageView,
+  formatResetText,
+  parseResetSeconds,
+} from "./tab-provider-usage.lib.ts";
+
+const RATE_FALLBACK_ZH = "速率限制";
+const RATE_FALLBACK_EN = "Rate Limit";
+
+const HOUR_USAGE_ZH = "{n} 小时用量";
+const HOUR_USAGE_EN = "{n}h usage";
+const MINUTE_USAGE_ZH = "{n} 分钟用量";
+const MINUTE_USAGE_EN = "{n}m usage";
+
+const labels = (locale: "zh" | "en") => ({
+  rateFallback: locale === "zh" ? RATE_FALLBACK_ZH : RATE_FALLBACK_EN,
+  hourUsage: locale === "zh" ? HOUR_USAGE_ZH : HOUR_USAGE_EN,
+  minuteUsage: locale === "zh" ? MINUTE_USAGE_ZH : MINUTE_USAGE_EN,
+});
+
+test("computeRateWindowLabel converts 300 MINUTE to '5 小时用量' (zh)", () => {
+  const limits = [{ window: { duration: 300, timeUnit: "MINUTE" } }];
+  assert.equal(computeRateWindowLabel(limits, "zh", labels("zh")), "5 小时用量");
+});
+
+test("computeRateWindowLabel converts 300 MINUTE to '5h usage' (en)", () => {
+  const limits = [{ window: { duration: 300, timeUnit: "MINUTE" } }];
+  assert.equal(computeRateWindowLabel(limits, "en", labels("en")), "5h usage");
+});
+
+test("computeRateWindowLabel: MINUTE not divisible by 60 stays in minutes", () => {
+  const limits = [{ window: { duration: 30, timeUnit: "MINUTE" } }];
+  assert.equal(computeRateWindowLabel(limits, "zh", labels("zh")), "30 分钟用量");
+  assert.equal(computeRateWindowLabel(limits, "en", labels("en")), "30m usage");
+});
+
+test("computeRateWindowLabel: HOUR is used directly", () => {
+  const limits = [{ window: { duration: 1, timeUnit: "HOUR" } }];
+  assert.equal(computeRateWindowLabel(limits, "zh", labels("zh")), "1 小时用量");
+  assert.equal(computeRateWindowLabel(limits, "en", labels("en")), "1h usage");
+});
+
+test("computeRateWindowLabel: timeUnit is case insensitive", () => {
+  const limits = [{ window: { duration: 60, timeUnit: "minute" } }];
+  assert.equal(computeRateWindowLabel(limits, "zh", labels("zh")), "1 小时用量");
+});
+
+test("computeRateWindowLabel: reads from limits[0] directly when no window", () => {
+  const limits = [{ duration: 120, timeUnit: "MINUTE" }];
+  assert.equal(computeRateWindowLabel(limits, "zh", labels("zh")), "2 小时用量");
+});
+
+test("computeRateWindowLabel: reads from limits[0].detail as third priority", () => {
+  const limits = [{ detail: { duration: 60, timeUnit: "MINUTE" } }];
+  assert.equal(computeRateWindowLabel(limits, "zh", labels("zh")), "1 小时用量");
+});
+
+test("computeRateWindowLabel: window beats top-level beats detail", () => {
+  const limits = [{
+    window: { duration: 60, timeUnit: "MINUTE" },
+    duration: 30, timeUnit: "MINUTE",
+    detail: { duration: 120, timeUnit: "MINUTE" },
+  }];
+  assert.equal(computeRateWindowLabel(limits, "zh", labels("zh")), "1 小时用量");
+});
+
+test("computeRateWindowLabel falls back when limits empty", () => {
+  assert.equal(computeRateWindowLabel([], "zh", labels("zh")), RATE_FALLBACK_ZH);
+  assert.equal(computeRateWindowLabel([], "en", labels("en")), RATE_FALLBACK_EN);
+});
+
+test("computeRateWindowLabel falls back when window metadata missing", () => {
+  assert.equal(computeRateWindowLabel([{ used: "10", limit: "100" }], "zh", labels("zh")), RATE_FALLBACK_ZH);
+});
+
+test("computeRateWindowLabel falls back when duration is 0 or negative", () => {
+  assert.equal(
+    computeRateWindowLabel([{ window: { duration: 0, timeUnit: "HOUR" } }], "zh", labels("zh")),
+    RATE_FALLBACK_ZH,
+  );
+  assert.equal(
+    computeRateWindowLabel([{ window: { duration: -5, timeUnit: "HOUR" } }], "zh", labels("zh")),
+    RATE_FALLBACK_ZH,
+  );
+});
+
+test("computeRateWindowLabel falls back when timeUnit unknown", () => {
+  assert.equal(
+    computeRateWindowLabel([{ window: { duration: 5, timeUnit: "DAY" } }], "zh", labels("zh")),
+    RATE_FALLBACK_ZH,
+  );
+});
+
+test("parseResetSeconds: reset_in numeric", () => {
+  assert.equal(parseResetSeconds({ reset_in: 3600 }), 3600);
+  assert.equal(parseResetSeconds({ resetIn: "1800" }), 1800);
+});
+
+test("parseResetSeconds: resetAt ISO timestamp in the future", () => {
+  const future = new Date(Date.now() + 3600 * 1000).toISOString();
+  const got = parseResetSeconds({ resetAt: future });
+  // Allow a few-second drift since clock advances during the call
+  assert.ok(got >= 3595 && got <= 3601, `got=${got}`);
+});
+
+test("parseResetSeconds: returns 0 when nothing present", () => {
+  assert.equal(parseResetSeconds({}), 0);
+  assert.equal(parseResetSeconds({ unrelated: 1 }), 0);
+});
+
+test("parseResetSeconds: window numeric falls back to duration", () => {
+  assert.equal(parseResetSeconds({ window: 600 }), 600);
+});
+
+test("formatResetText: '5小时后重置' / '5h reset' — no '重置于' prefix", () => {
+  assert.equal(formatResetText(3600 * 5, "zh"), "5小时后重置");
+  assert.equal(formatResetText(3600 * 5, "en"), "5h reset");
+});
+
+test("formatResetText: minutes when under an hour", () => {
+  assert.equal(formatResetText(60 * 30, "zh"), "30分钟后重置");
+  assert.equal(formatResetText(60 * 30, "en"), "30m reset");
+});
+
+test("formatResetText: 0 returns empty string (no reset row)", () => {
+  assert.equal(formatResetText(0, "zh"), "");
+  assert.equal(formatResetText(-5, "en"), "");
+});
+
+test("deriveUsageView: percentage card displays whole percent", () => {
+  const data = {
+    usage: { used: "480", limit: "1000" },
+    limits: [{ used: "30", limit: "100", window: { duration: 300, timeUnit: "MINUTE" } }],
+  };
+  const view = deriveUsageView(data, "zh", labels("zh"));
+  assert.equal(view.week!.pctText, "48%");
+  assert.equal(view.week!.rawText, "480 / 1000");
+  assert.equal(view.rate!.pctText, "30%");
+  assert.equal(view.rate!.title, "5 小时用量");
+  assert.equal(view.rate!.rawText, "30 / 100");
+});
+
+test("deriveUsageView: derives used from remaining when used missing", () => {
+  const data = {
+    usage: { remaining: "200", limit: "1000" },
+    limits: [],
+  };
+  const view = deriveUsageView(data, "zh", labels("zh"));
+  assert.equal(view.week!.pctText, "80%");
+  assert.equal(view.week!.rawText, "800 / 1000");
+});
+
+test("deriveUsageView: limits[0].detail path still drives usage numbers", () => {
+  const data = {
+    usage: { used: "10", limit: "100" },
+    limits: [{ detail: { used: "75", limit: "100", window: { duration: 60, timeUnit: "MINUTE" } } }],
+  };
+  const view = deriveUsageView(data, "zh", labels("zh"));
+  assert.equal(view.rate!.pctText, "75%");
+  assert.equal(view.rate!.rawText, "75 / 100");
+  assert.equal(view.rate!.title, "1 小时用量");
+});
+
+test("deriveUsageView: rate card title falls back to 速率限制 when window missing", () => {
+  const data = {
+    usage: { used: "10", limit: "100" },
+    limits: [{ used: "5", limit: "10" }],
+  };
+  const view = deriveUsageView(data, "zh", labels("zh"));
+  assert.equal(view.rate!.title, RATE_FALLBACK_ZH);
+  assert.equal(view.rate!.pctText, "50%");
+});
+
+test("deriveUsageView: reset text has no 重置于 prefix", () => {
+  const data = {
+    usage: { used: "10", limit: "100", reset_in: 7200 },
+    limits: [{ used: "5", limit: "10", resetIn: 1800, window: { duration: 60, timeUnit: "MINUTE" } }],
+  };
+  const view = deriveUsageView(data, "zh", labels("zh"));
+  assert.equal(view.week!.resetText, "2小时后重置");
+  assert.equal(view.rate!.resetText, "30分钟后重置");
+  // English variant
+  const enView = deriveUsageView(data, "en", labels("en"));
+  assert.equal(enView.week!.resetText, "2h reset");
+  assert.equal(enView.rate!.resetText, "30m reset");
+});
+
+test("deriveUsageView: rate card omitted when limits empty", () => {
+  const data = { usage: { used: "0", limit: "1000" }, limits: [] };
+  const view = deriveUsageView(data, "zh", labels("zh"));
+  assert.equal(view.week!.pctText, "0%");
+  assert.equal(view.rate, null);
+});
+
+test("deriveUsageView: tolerates non-object payload", () => {
+  const empty = deriveUsageView(null, "zh", labels("zh"));
+  assert.equal(empty.week, null);
+  assert.equal(empty.rate, null);
+});
+
+test("deriveUsageView: zero limit results in 0% (no NaN/Infinity)", () => {
+  const data = { usage: { used: "0", limit: "0" }, limits: [] };
+  const view = deriveUsageView(data, "zh", labels("zh"));
+  assert.equal(view.week!.pctText, "0%");
+  assert.equal(view.week!.pct, 0);
+});
+
+test("deriveUsageView: percent caps at 100 even if usage exceeds limit", () => {
+  const data = { usage: { used: "1200", limit: "1000" }, limits: [] };
+  const view = deriveUsageView(data, "zh", labels("zh"));
+  assert.equal(view.week!.pctText, "100%");
+  assert.equal(view.week!.pct, 100);
+});

--- a/chat-ui/ui/src/ui/views/settings/tab-provider.ts
+++ b/chat-ui/ui/src/ui/views/settings/tab-provider.ts
@@ -14,6 +14,7 @@ import {
   PROVIDERS, CUSTOM_PRESETS, KIMI_CODE_MODELS, SUB_PLATFORM_URLS,
   CUSTOM_MODEL_SENTINEL, PROVIDER_DISPLAY_ORDER, getProviderLabels,
 } from "../setup/setup-constants.ts";
+import { deriveUsageView, type UsageLabels } from "./tab-provider-usage.lib.ts";
 
 /* ── types ── */
 
@@ -46,6 +47,7 @@ function createProviderState() {
     error: null as string | null,
     successMsg: null as string | null,
     usageData: null as any,
+    usageLoading: false,
     apiKey: "",
     modelId: "",
     customModelId: "",
@@ -175,38 +177,6 @@ function fillSavedProviderFields(saved: any) {
   if (saved.api) s.apiType = saved.api;
   if (saved.supportImage !== undefined) s.imageSupport = !!saved.supportImage;
   if (saved.customPreset) s.customPreset = saved.customPreset;
-}
-
-function formatResetDuration(seconds: number): string {
-  if (!seconds || seconds <= 0) return "";
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const isZh = getLocale() === "zh";
-  if (h > 0) return h + (isZh ? "小时后重置" : "h reset");
-  if (m > 0) return m + (isZh ? "分钟后重置" : "m reset");
-  return isZh ? "即将重置" : "resetting soon";
-}
-
-function parseResetAt(val: string): number {
-  if (!val) return 0;
-  try {
-    let str = String(val);
-    if (str.includes(".") && str.endsWith("Z")) {
-      const parts = str.slice(0, -1).split(".");
-      str = parts[0] + "." + parts[1].slice(0, 3) + "Z";
-    }
-    const dt = new Date(str);
-    const diff = (dt.getTime() - Date.now()) / 1000;
-    return diff > 0 ? Math.round(diff) : 0;
-  } catch { return 0; }
-}
-
-function extractResetSeconds(data: any): number {
-  const keys = ["reset_at", "resetAt", "reset_time", "resetTime"];
-  for (const k of keys) { if (data[k]) return parseResetAt(data[k]); }
-  const durKeys = ["reset_in", "resetIn", "ttl", "window"];
-  for (const k of durKeys) { const v = parseInt(data[k], 10); if (v > 0) return v; }
-  return 0;
 }
 
 /* ── build params / payload ── */
@@ -512,11 +482,19 @@ async function checkOAuthStatus(state: AppViewState) {
 
 async function loadUsage(state: AppViewState) {
   if (!isKimiCodeProvider()) return;
+  if (s.usageLoading) return;
+  s.usageLoading = true;
+  state.requestUpdate();
   try {
     const result = await ipc.kimiGetUsage();
     if (result?.data) s.usageData = result.data;
+  } catch {
+    // Silent: refresh failures keep the existing data visible; first-load
+    // failures keep the panel hidden (usageData stays null).
+  } finally {
+    s.usageLoading = false;
     state.requestUpdate();
-  } catch {}
+  }
 }
 
 function onProviderChange(provider: string, state: AppViewState) {
@@ -733,6 +711,28 @@ function injectStyles() {
       transition: width 0.3s ease;
     }
     .oc-provider-usage-reset { font-size: 11px; color: var(--text-muted, #a1a1aa); white-space: nowrap; }
+    .oc-provider-usage-wrap { display: flex; flex-direction: column; gap: 6px; }
+    .oc-provider-usage-toolbar { display: flex; justify-content: flex-end; }
+    .oc-provider-usage-refresh {
+      width: 24px;
+      height: 24px;
+      border-radius: 6px;
+      border: 1px solid var(--border, #e0e0e0);
+      background: transparent;
+      color: var(--text-muted, #71717a);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      padding: 0;
+    }
+    .oc-provider-usage-refresh:hover:not(:disabled) {
+      color: var(--text-strong, #18181b);
+      background: var(--bg-secondary, #fbfbfb);
+    }
+    .oc-provider-usage-refresh:disabled { cursor: progress; opacity: 0.7; }
+    .oc-provider-usage-refresh.is-loading svg { animation: oc-setup-spin 0.8s linear infinite; }
+    @keyframes oc-setup-spin { to { transform: rotate(360deg); } }
 
     /* Collapse indicator */
     .oc-provider-collapse { margin-bottom: 8px; }
@@ -1025,38 +1025,51 @@ function renderOAuthSection(state: AppViewState) {
 
 function renderUsagePanel(state: AppViewState) {
   if (!s.usageData) return nothing;
-  const data = s.usageData;
+  const locale = getLocale() === "zh" ? "zh" : "en";
+  const labels: UsageLabels = {
+    rateFallback: t("settings.provider.usage.rateLimit"),
+    hourUsage: t("settings.provider.usage.hourUsage"),
+    minuteUsage: t("settings.provider.usage.minuteUsage"),
+  };
+  const view = deriveUsageView(s.usageData, locale, labels);
+  if (!view.week && !view.rate) return nothing;
 
-  const usage = data.usage ?? {};
-  const usedW = parseInt(usage.used ?? "0", 10) || (usage.remaining !== undefined ? ((parseInt(usage.limit ?? "0", 10) || 0) - (parseInt(usage.remaining ?? "0", 10) || 0)) : 0);
-  const limitW = parseInt(usage.limit ?? "0", 10) || 0;
-  const resetW = extractResetSeconds(usage);
-  const pctW = limitW > 0 ? Math.min(100, (usedW / limitW) * 100) : 0;
-
-  const limits = Array.isArray(data.limits) ? data.limits : [];
-  let usedL = 0, limitL = 0, resetL = 0;
-  if (limits.length > 0) {
-    const item = limits[0];
-    const detail = (item.detail && typeof item.detail === "object") ? item.detail : item;
-    usedL = parseInt(detail.used ?? "0", 10) || (detail.remaining !== undefined ? ((parseInt(detail.limit ?? "0", 10) || 0) - (parseInt(detail.remaining ?? "0", 10) || 0)) : 0);
-    limitL = parseInt(detail.limit ?? "0", 10) || 0;
-    resetL = extractResetSeconds(detail);
-  }
-  const pctL = limitL > 0 ? Math.min(100, (usedL / limitL) * 100) : 0;
+  const refreshTitle = t("settings.provider.usage.refresh");
+  const renderCard = (card: NonNullable<typeof view.week>) => html`
+    <div class="oc-provider-usage-card" title=${card.rawText}>
+      <div class="oc-provider-usage-title">${card.title || t("settings.provider.usage.weekUsage")}</div>
+      <div class="oc-provider-usage-value">${card.pctText}</div>
+      <div class="oc-provider-usage-bar"><div class="oc-provider-usage-bar-fill" style="width:${card.pct}%"></div></div>
+      ${card.resetText ? html`<div class="oc-provider-usage-reset">${card.resetText}</div>` : nothing}
+    </div>
+  `;
+  const weekCard = view.week
+    ? renderCard({ ...view.week, title: t("settings.provider.usage.weekUsage") })
+    : nothing;
+  const rateCard = view.rate ? renderCard(view.rate) : nothing;
 
   return html`
-    <div class="oc-provider-usage">
-      <div class="oc-provider-usage-card">
-        <div class="oc-provider-usage-title">${t("settings.provider.usage.weekUsage")}</div>
-        <div class="oc-provider-usage-value">${usedW} / ${limitW}</div>
-        <div class="oc-provider-usage-bar"><div class="oc-provider-usage-bar-fill" style="width:${pctW}%"></div></div>
-        ${resetW > 0 ? html`<div class="oc-provider-usage-reset">${t("settings.provider.usage.resetIn")} ${formatResetDuration(resetW)}</div>` : nothing}
+    <div class="oc-provider-usage-wrap">
+      <div class="oc-provider-usage-toolbar">
+        <button
+          class="oc-provider-usage-refresh ${s.usageLoading ? "is-loading" : ""}"
+          title=${refreshTitle}
+          aria-label=${refreshTitle}
+          ?disabled=${s.usageLoading}
+          @click=${() => loadUsage(state)}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 12a9 9 0 0 1 15-6.7L21 8"/>
+            <path d="M21 3v5h-5"/>
+            <path d="M21 12a9 9 0 0 1-15 6.7L3 16"/>
+            <path d="M3 21v-5h5"/>
+          </svg>
+        </button>
       </div>
-      <div class="oc-provider-usage-card">
-        <div class="oc-provider-usage-title">${t("settings.provider.usage.rateLimit")}</div>
-        <div class="oc-provider-usage-value">${usedL} / ${limitL}</div>
-        <div class="oc-provider-usage-bar"><div class="oc-provider-usage-bar-fill" style="width:${pctL}%"></div></div>
-        ${resetL > 0 ? html`<div class="oc-provider-usage-reset">${t("settings.provider.usage.resetIn")} ${formatResetDuration(resetL)}</div>` : nothing}
+      <div class="oc-provider-usage">
+        ${weekCard}
+        ${rateCard}
       </div>
     </div>
   `;

--- a/src/settings-ipc.ts
+++ b/src/settings-ipc.ts
@@ -1620,9 +1620,10 @@ export function registerSettingsIpc(opts: SettingsIpcOptions = {}): void {
   ipcMain.handle("kimi:get-usage", async () => {
     try {
       const config = readUserConfig();
-      const info = extractProviderInfo(config);
-      // 仅 kimi-code 子平台支持用量查询
-      if (info.provider !== "moonshot" || info.subPlatform !== "kimi-code") {
+      // 仅要求 Kimi Code provider 已配置即可，不再绑定默认模型。
+      // 允许「列表里选中 Kimi Code 但当前默认是别的模型」时也能查到用量。
+      const isKimiCodeConfigured = !!(config?.models?.providers?.["kimi-coding"]?.apiKey);
+      if (!isKimiCodeConfigured) {
         return { success: false, message: "Usage is only available for Kimi." };
       }
       const { loadOAuthToken, refreshOAuthToken } = await import("./kimi-oauth");


### PR DESCRIPTION
  ## 目标

  修复 Kimi Code 已配置但未设为默认模型时，设置页无法展示 Kimi 用量信息的问题。该 PR 让 Kimi 用量
  入口与“当前默认模型”解耦，确保用户只要完成 Kimi Code 配置，就能稳定查看对应的额度与使用情况。

  ## 主要改动

  - 调整 Provider Usage 的 Kimi 展示与拉取逻辑，从依赖默认 provider/model 改为基于 Kimi Code 配置
  状态判断。
  - 补充 Kimi 用量接口响应的解析与兼容处理，支持现有测试覆盖的多种返回结构。
  - 更新相关单元测试，覆盖“Kimi Code 已配置但不是默认模型”场景，防止后续回归。